### PR TITLE
Implement dark and light mode with Next Themes

### DIFF
--- a/apps/web/src/app/components/header.tsx
+++ b/apps/web/src/app/components/header.tsx
@@ -5,6 +5,7 @@ import { Drawer, DrawerContent, DrawerFooter, DrawerTrigger } from "@repo/ui/com
 import { Separator } from "@repo/ui/components/ui/separator";
 import { Menu } from "lucide-react";
 import Link from "next/link";
+import { ThemeToggle } from "./theme-toggle";
 
 async function getLastUpdateDate() {
   try {
@@ -67,6 +68,7 @@ export async function Header() {
               <span className="sr-only">GitHub</span>
             </a>
           </Button>
+          <ThemeToggle />
         </div>
 
         {/* Mobile Navigation */}

--- a/apps/web/src/app/components/theme-toggle.tsx
+++ b/apps/web/src/app/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className="flex items-center w-40 bg-gray-100 dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-md p-1 shadow-sm space-x-1">
+      {['light', 'dark'].map((mode) => (
+        <button
+          key={mode}
+          onClick={() => setTheme(mode)}
+          className={`h-8 px-3 w-1/2 text-sm rounded-md flex items-center justify-center transition-all duration-200 ${
+            theme === mode
+              ? 'bg-white dark:bg-zinc-700 text-gray-900 dark:text-zinc-100 shadow-sm'
+              : 'bg-gray-100 dark:bg-zinc-800 border-none text-gray-600 dark:text-zinc-400 hover:bg-gray-200 dark:hover:bg-zinc-600'
+          }`}
+        >
+          {mode === 'light' ? (
+            <>
+              <Sun size={14} className="mr-2" />
+              Light
+            </>
+          ) : (
+            <>
+              <Moon size={14} className="mr-2" />
+              Dark
+            </>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { Footer } from "./components/footer";
 import { Header } from "./components/header";
+import { ThemeProvider } from "next-themes";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -31,13 +32,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Header />
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />
-        
-        <div className="min-h-screen bg-gradient-to-b from-background to-secondary">
-          {children}
-        </div>
-        <Footer />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <Header />
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />
+          
+          <div className="min-h-screen bg-gradient-to-b from-background to-secondary">
+            {children}
+          </div>
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
Implement dark and light mode functionality using `next-themes` in the Next.js project and add a theme toggle component to the header.

* **ThemeProvider**: Add `ThemeProvider` from `next-themes` to wrap the application in `apps/web/src/app/layout.tsx`.
* **Header Component**: Import and add the new `ThemeToggle` component to the header next to social icons in `apps/web/src/app/components/header.tsx`.
* **ThemeToggle Component**: Create a new `ThemeToggle` component in `apps/web/src/app/components/theme-toggle.tsx` to manage theme state and toggle between light and dark modes using `useTheme` from `next-themes`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/felipebarcelospro/shadcn-theme-creator-for-chrome?shareId=9fd56c29-0b39-4452-bd9c-209928b433e1).